### PR TITLE
Issue at 'render_rmd()' solved.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: yamlme
-Version: 0.1.2.9001
+Version: 0.1.3
 Encoding: UTF-8
 Title: Writing 'YAML' Headers for 'R-Markdown' Documents
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,9 @@
-# yamlme 0.1.3
+# yamlme 0.2.0
 
 ### Bug Fixes
 
 - Function `render_rmd()` is now overwritten previous versions of rendered
   files.
-
 
 
 # yamlme 0.1.2

--- a/R/render_rmd.R
+++ b/R/render_rmd.R
@@ -82,8 +82,10 @@ render_rmd.rmd_doc <- function(input, output_file, delete_rmd = TRUE, ...) {
   if (delete_rmd) {
     files_tmp <- files_tmp[!grepl(".Rmd", files_tmp, fixed = TRUE)]
   }
-  file.copy(
-    from = file.path(tempdir(), files_tmp), to = dirname(output_file),
-    overwrite = TRUE
-  )
+  if (dirname(output_file) != tempdir()) {
+    file.copy(
+      from = file.path(tempdir(), files_tmp), to = dirname(output_file),
+      overwrite = TRUE
+    )
+  }
 }


### PR DESCRIPTION
An error caused by the function `render_rmd()` if the destination folder is `tempdir()`, since rendered document was cancelled in such case.

Closes #15 